### PR TITLE
Add *.symbaloo.com domains to whitelist

### DIFF
--- a/src/whitelist.txt
+++ b/src/whitelist.txt
@@ -3111,6 +3111,7 @@ leseraupe.tsn.at
 lessonopoly.org
 lessonplancentral.com
 lessonplans.btskinner.com
+lessonplan.symbaloo.com
 lessonplanz.com
 lester.rice.edu
 levine.sscnet.ucla.edu
@@ -19325,3 +19326,4 @@ www.wachovia.com
 www.wellsfargo.com
 www.workforce3one.org
 www3.nationalgeographic.com
+www.symbaloo.com

--- a/src/whitelist.txt
+++ b/src/whitelist.txt
@@ -3111,8 +3111,7 @@ leseraupe.tsn.at
 lessonopoly.org
 lessonplancentral.com
 lessonplans.btskinner.com
-lessonplan.symbaloo.com
-lessonplanz.com
+lessonplans.symbaloo.com
 lester.rice.edu
 levine.sscnet.ucla.edu
 lewisclark.net

--- a/src/whitelist.txt
+++ b/src/whitelist.txt
@@ -3112,6 +3112,7 @@ lessonopoly.org
 lessonplancentral.com
 lessonplans.btskinner.com
 lessonplans.symbaloo.com
+lessonplanz.com
 lester.rice.edu
 levine.sscnet.ucla.edu
 lewisclark.net


### PR DESCRIPTION
Register learning registry publications with symbaloo.com domain names on the LR-Data parser/indexer
